### PR TITLE
Fix wrong path

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func getContentSops(path string) string {
 
 		return string(data)
 	} else {
-		data, err := decrypt.File(path, "yaml")
+		data, err := decrypt.File(s, "yaml")
 
 		if err != nil {
 			os.Exit(0)


### PR DESCRIPTION
When trying to decrypt data, wrong path was passed to the sops plugin.